### PR TITLE
Revert "Bump micromatch from 4.0.7 to 4.0.8 in /docs in the npm_and_yarn group"

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10195,9 +10195,9 @@
             ]
         },
         "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"


### PR DESCRIPTION
Reverts RealBradCool/Bradtendo-Docker#1